### PR TITLE
Add block form to Nenv() helper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ puts git.pager
 puts git.editor
 ```
 
+Or in block form
+
+```ruby
+Nenv :git do |git|
+  puts git.browser
+  puts git.pager
+  puts git.editor
+end
+```
+
 ### Custom type handling
 
 ```ruby

--- a/lib/nenv.rb
+++ b/lib/nenv.rb
@@ -4,7 +4,9 @@ require 'nenv/autoenvironment'
 require 'nenv/builder'
 
 def Nenv(namespace = nil)
-  Nenv::AutoEnvironment.new(namespace)
+  Nenv::AutoEnvironment.new(namespace).tap do |env|
+    yield env if block_given?
+  end
 end
 
 module Nenv

--- a/spec/lib/nenv_spec.rb
+++ b/spec/lib/nenv_spec.rb
@@ -16,6 +16,24 @@ RSpec.describe Nenv do
     end
   end
 
+  describe 'Nenv() helper method with block' do
+    it 'reads from env' do
+      expect(ENV).to receive(:[]).with('GIT_BROWSER').and_return('chrome')
+      Nenv('git') do |git|
+        git.browser
+      end
+    end
+
+    it 'return the value from env' do
+      allow(ENV).to receive(:[]).with('GIT_BROWSER').and_return('firefox')
+      result = nil
+      Nenv('git') do |git|
+        result = git.browser
+      end
+      expect(result).to eq('firefox')
+    end
+  end
+
   describe 'Nenv module' do
     it 'reads from env' do
       expect(ENV).to receive(:[]).with('CI').and_return('true')


### PR DESCRIPTION
I added a Ruby-ism to allow using the Nenv(:namespace) helper in block form. It avoids creating a local variable, but mostly I like the way it looks.

Here's how I use it in my application:

```ruby
Nenv :filepicker do |fp|
  Rails.application.config.filepicker_rails.api_key = fp.api_key
  Rails.application.config.filepicker_rails.cdn_host = "https://#{fp.cdn}"
end
```