### PR TITLE
Accessor method creation refactoring.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 bundler_args: --without development
+before_install: gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/lib/nenv/environment.rb
+++ b/lib/nenv/environment.rb
@@ -22,12 +22,8 @@ module Nenv
       @namespace = (namespace ? namespace.upcase : nil)
     end
 
-    def self.create_method(meth, &block)
-      _create_env_method(self, meth, &block)
-    end
-
     def create_method(meth, &block)
-      self.class._create_env_method(class << self; self; end, meth, &block)
+      self.class._create_env_accessor(singleton_class, meth, &block)
     end
 
     private
@@ -36,23 +32,46 @@ module Nenv
       meth.to_s[/^([^=?]*)[=?]?$/, 1].upcase
     end
 
-    def self._create_env_method(instance, meth, &block)
-      _fail_if_exists(instance, meth)
+    def _namespaced_sanitize(meth)
+      [@namespace, _sanitize(meth)].compact.join('_')
+    end
 
-      instance.send(:define_method, meth) do |*args|
-        env_name = [@namespace, _sanitize(meth)].compact.join('_')
+    class << self
+      def create_method(meth, &block)
+        _create_env_accessor(self, meth, &block)
+      end
 
-        if args.size == 1
-          raw_value = args.first
-          ENV[env_name] = Dumper.new.dump(raw_value, &block)
+      def _create_env_accessor(klass, meth, &block)
+        _fail_if_accessor_exists(klass, meth)
+
+        if meth.to_s.end_with? '='
+          _create_env_writer(klass, meth, &block)
         else
+          _create_env_reader(klass, meth, &block)
+        end
+      end
+
+      private
+
+      def _create_env_writer(klass, meth, &block)
+        env_name = nil
+        klass.send(:define_method, meth) do |raw_value|
+          env_name ||= _namespaced_sanitize(meth)
+          ENV[env_name] = Dumper.new.dump(raw_value, &block)
+        end
+      end
+
+      def _create_env_reader(klass, meth, &block)
+        env_name = nil
+        klass.send(:define_method, meth) do
+          env_name ||= _namespaced_sanitize(meth)
           Loader.new(meth).load(ENV[env_name], &block)
         end
       end
-    end
 
-    def self._fail_if_exists(instance, meth)
-      fail(AlreadyExistsError, meth) if instance.instance_methods.include?(meth)
+      def _fail_if_accessor_exists(klass, meth)
+        fail(AlreadyExistsError, meth) if klass.method_defined?(meth)
+      end
     end
   end
 end


### PR DESCRIPTION
This refactoring does a couple of things:

- Separates declarations of reader and writer (`foo` and `foo=`).
- There's no need in `*args`-splat hack, so temporary array won't be creating on each call.
- `env_name` is lazy initialized now, so temporary string won't be creating on each call.
- class methods are extracted into the `self << class` context.
- `_fail_if_accessor_exists` and other private class methods made really private.
- Some renamings done.